### PR TITLE
ci: add dummy supabase env so build will succeed

### DIFF
--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -59,7 +59,7 @@ jobs:
 
       - name: Set supabase env vars
         run: |
-          echo "SUPABASE_URL=supabase" >> "$GITHUB_ENV"
+          echo "SUPABASE_URL=https://supabase.com" >> "$GITHUB_ENV"
           echo "SUPABASE_SERVICE_ROLE_KEY=supabase" >> "$GITHUB_ENV"
 
       - name: Build

--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -57,5 +57,10 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-nextjs-${{ hashFiles('**/pnpm-lock.json') }}-
 
+      - name: Set supabase env vars
+        run: |
+          echo "SUPABASE_URL=supabase" >> "$GITHUB_ENV"
+          echo "SUPABASE_SERVICE_ROLE_KEY=supabase" >> "$GITHUB_ENV"
+
       - name: Build
         run: pnpm run build


### PR DESCRIPTION
## Context

The current build fails in the github actions pipeline as the 2 environments variables required for supabase are missing